### PR TITLE
Add test for rendering rocket cards in Rockets component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-router-dom": "^6.16.0",
         "react-scripts": "5.0.1",
         "react-test-renderer": "^18.2.0",
+        "redux-mock-store": "^1.5.4",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -13688,6 +13689,11 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -17614,6 +17620,14 @@
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-mock-store": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.4.tgz",
+      "integrity": "sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==",
+      "dependencies": {
+        "lodash.isplainobject": "^4.0.6"
       }
     },
     "node_modules/redux-thunk": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-router-dom": "^6.16.0",
     "react-scripts": "5.0.1",
     "react-test-renderer": "^18.2.0",
+    "redux-mock-store": "^1.5.4",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/__tests__/Rockets.test.jsx
+++ b/src/__tests__/Rockets.test.jsx
@@ -1,0 +1,44 @@
+import '@testing-library/jest-dom/extend-expect';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import Rockets from '../components/Rockets';
+
+const mockStore = configureStore([]);
+
+describe('Rockets Component', () => {
+  let store;
+
+  beforeEach(() => {
+    store = mockStore({
+      rockets: [
+        {
+          id: 1,
+          rocket_name: 'Falcon 1',
+          description: 'Description of Falcon 1',
+          reserved: false,
+          flickr_images: ['image_url'],
+        },
+        {
+          id: 2,
+          rocket_name: 'Falcon 9',
+          description: 'Description of Falcon 9',
+          reserved: false,
+          flickr_images: ['image_url'],
+        },
+      ],
+    });
+  });
+
+  it('should render rocket cards', () => {
+    const { getAllByTestId } = render(
+      <Provider store={store}>
+        <Rockets />
+      </Provider>,
+    );
+
+    const rocketCards = getAllByTestId('rocket-card');
+    expect(rocketCards).toHaveLength(2);
+  });
+});

--- a/src/components/Rockets.jsx
+++ b/src/components/Rockets.jsx
@@ -30,7 +30,7 @@ const Rockets = () => {
     <div className="roc-container">
       {rocketData.length > 0
         && rocketData.map((rocket) => (
-          <div key={rocket.id} className={`roc-card ${rocket.reserved ? 'reserved' : ''}`}>
+          <div key={rocket.id} className={`roc-card ${rocket.reserved ? 'reserved' : ''}`} data-testid="rocket-card">
             <div className="roc-image-container">
               <img src={rocket.flickr_images[0]} alt={rocket.name} className="roc-image" />
             </div>


### PR DESCRIPTION
# Add test for rendering rocket cards in Rockets component

This pull request adds a test case for the Rockets component to ensure that it correctly renders rocket cards based on the provided mock store state.

## Changes

- Added unit tests for rendering and data display in the `Rockets` component.

_**Please review and merge this pull request to incorporate the tests for the Rockets component into the project.
Thank you!**_